### PR TITLE
message validity: operator, stake, 2hr timestamp, no disputes

### DIFF
--- a/src/ethClient.ts
+++ b/src/ethClient.ts
@@ -1,17 +1,40 @@
+import {
+  registryABI,
+  registryAddress,
+} from "./registry-contract/registryContract";
 import { ethers } from "ethers";
 import { JsonRpcProvider } from "@ethersproject/providers";
 
 export class EthClient {
   provider: JsonRpcProvider;
+  goerliProvider: JsonRpcProvider;
+  registryContract: ethers.Contract;
 
   constructor() {
     const provider = new ethers.providers.JsonRpcProvider(
       `http://${process.env.ETH_NODE}`
     );
+    const goerliProvider = new ethers.providers.JsonRpcProvider(
+      process.env.GOERLI_NODE
+    );
     this.provider = provider;
+    this.goerliProvider = goerliProvider;
+    this.registryContract = new ethers.Contract(
+      registryAddress,
+      registryABI,
+      goerliProvider
+    );
   }
 
   async getBlockNumber(): Promise<number> {
     return await this.provider.getBlockNumber();
+  }
+
+  async checkRegistry(indexerAddress: string, operatorAddress: string) {
+    console.log(`check registry`, { contract: this.registryContract });
+    return await this.registryContract.operatorAuth(
+      indexerAddress,
+      operatorAddress
+    );
   }
 }

--- a/src/registry-contract/registryContract.ts
+++ b/src/registry-contract/registryContract.ts
@@ -1,0 +1,71 @@
+export const registryAddress = "0xc97d66A0ef6093a306877671a78FaCA873C0ECA8";
+
+export const registryABI = [
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "address",
+        name: "indexer",
+        type: "address",
+      },
+      {
+        indexed: true,
+        internalType: "address",
+        name: "operator",
+        type: "address",
+      },
+      {
+        indexed: false,
+        internalType: "bool",
+        name: "allowed",
+        type: "bool",
+      },
+    ],
+    name: "SetGossipOperator",
+    type: "event",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "",
+        type: "address",
+      },
+      {
+        internalType: "address",
+        name: "",
+        type: "address",
+      },
+    ],
+    name: "operatorAuth",
+    outputs: [
+      {
+        internalType: "bool",
+        name: "",
+        type: "bool",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "_operator",
+        type: "address",
+      },
+      {
+        internalType: "bool",
+        name: "_allowed",
+        type: "bool",
+      },
+    ],
+    name: "setGossipOperator",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+];


### PR DESCRIPTION
### Description
Add gossip operator subgraph queries for message validity, reformat message validity checks. Temporarily using checks for 
1) message sender is an operator of an indexer (maybe it could be any `graphAccount`, so interested to hear thoughts to update the query check to that id
2) indexer self-stake is at least the network's indexer minimum stake
3) Timestamp from the message within the last hour (3_600_000ms)
4) (MAYBE - implemented but it could be too harsh and no reason to blacklist, maybe up-to individual preferences?) indexer has never been slashed before

### Issue link (if applicable)
[Link to issue]()
