### PR TITLE
running multiple instances either good or bad

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,9 +12,9 @@ WORKDIR /usr/app/dist/src/examples/poi-crosschecker
 ENV REGISTRY_SUBGRAPH "https://api.thegraph.com/subgraphs/name/juanmardefago/gossip-network-subgraph"
 ENV NETWORK_URL "https://gateway.testnet.thegraph.com/network"
 ENV TERM "xterm-256color"
-ENV GRAPH_NODE host.docker.internal:8030
-ENV ETH_NODE host.docker.internal:8545
-ENV INDEXER_MANAGEMENT_SERVER_PORT host.docker.internal:18000
+ENV GRAPH_NODE http://host.docker.internal:8030/graphql
+ENV ETH_NODE http://host.docker.internal:8545
+ENV INDEXER_MANAGEMENT_SERVER_PORT http://host.docker.internal:18000
 ENV RADIO_OPERATOR_PRIVATE_KEY "<RADIO_OPERATOR_PRIVATE_KEY>"
 
 CMD node poi-crosschecker.js

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,12 +9,12 @@ RUN npm run build
 
 WORKDIR /usr/app/dist/src/examples/poi-crosschecker
 
-ENV GRAPH_NODE_HOST "host.docker.internal"
-ENV ETH_NODE "host.docker.internal:8545"
+ENV REGISTRY_SUBGRAPH "https://api.thegraph.com/subgraphs/name/juanmardefago/gossip-network-subgraph"
 ENV NETWORK_URL "https://gateway.testnet.thegraph.com/network"
 ENV TERM "xterm-256color"
-ENV REGISTRY_SUBGRAPH "https://api.thegraph.com/subgraphs/name/juanmardefago/gossip-network-subgraph"
-ENV INDEXER_MANAGERMENT_SERVER "host.docker.internal:18000"
+ENV GRAPH_NODE host.docker.internal:8030
+ENV ETH_NODE host.docker.internal:8545
+ENV INDEXER_MANAGEMENT_SERVER_PORT host.docker.internal:18000
 ENV RADIO_OPERATOR_PRIVATE_KEY "<RADIO_OPERATOR_PRIVATE_KEY>"
 
 CMD node poi-crosschecker.js

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,23 +1,34 @@
 version: "3.8"
 
 services:
-  poi-crosschecker:
-    container_name: good-folk-1
+  good-indexer:
     build:
       context: .
       dockerfile: ./Dockerfile
-    command: echo 'running' | ls
+    command: node poi-crosschecker.js
+    env_file:
+      - .env
     environment:
-      ETH_NODE: host.docker.internal:8545
-      GRAPH_NODE_HOST: host.docker.internal
-      INDEXER_MANAGERMENT_SERVER: host.docker.internal:18000
-      RADIO_OPERATOR_PRIVATE_KEY: 806ccd0301ec455bfc94c71c9d199de4ce8838717a15da0a57a5d2cdc717bb5c
-    networks:
-      default:
-    # user: ${CURRENT_UID:?"Please run as follows 'CURRENT_UID=$(id -u):$(id -g) docker-compose up'"}
-    volume:
-      - .:/dist/src/examples/poi-crosschecker
-      - poi_crosschecker_node_modules:/src/examples/poi-crosschecker/node_modules
+      - GRAPH_NODE=host.docker.internal:8030
 
-volumes:
-  poi_crosschecker_node_modules:
+  wiremock:
+    image: wiremock/wiremock
+    command:
+      - '--enable-browser-proxying=true'
+    container_name: wiremock
+    volumes:
+      - ./src/tests/integration:/home/wiremock/
+    ports:
+      - 8031:8080
+
+  bad-indexer:
+    build:
+      context: .
+      dockerfile: ./Dockerfile
+    links:
+      - wiremock
+    command: node poi-crosschecker.js
+    env_file:
+      - a.env
+    environment:
+      - GRAPH_NODE=host.docker.internal:8031/mock

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     env_file:
       - .env
     environment:
-      - GRAPH_NODE=host.docker.internal:8030
+      - GRAPH_NODE=http://host.docker.internal:8030
 
   wiremock:
     image: wiremock/wiremock
@@ -31,4 +31,4 @@ services:
     env_file:
       - a.env
     environment:
-      - GRAPH_NODE=host.docker.internal:8031/mock
+      - GRAPH_NODE=http://host.docker.internal:8031/mock

--- a/src/ethClient.ts
+++ b/src/ethClient.ts
@@ -16,10 +16,6 @@ export class EthClient {
     this.wallet = wallet.connect(provider);
   }
 
-  async getBlockNumber(): Promise<number> {
-    return await this.provider.getBlockNumber();
-  }
-
   async getEthBalance(): Promise<number> {
     const balance = await this.wallet.getBalance();
     return parseFloat(utils.formatEther(balance));

--- a/src/examples/poi-crosschecker/poi-crosschecker.ts
+++ b/src/examples/poi-crosschecker/poi-crosschecker.ts
@@ -20,10 +20,10 @@ const RADIO_PAYLOAD_TYPES = [
 const run = async () => {
   const clientManager = new ClientManager({
     operatorPrivateKey: process.env.RADIO_OPERATOR_PRIVATE_KEY,
-    ethNodeUrl: `http://${process.env.ETH_NODE}`,
+    ethNodeUrl: process.env.ETH_NODE,
     registry: process.env.REGISTRY_SUBGRAPH,
-    graphNodeStatus: `http://${process.env.GRAPH_NODE}/graphql`,
-    indexerManagementServer: `http://${process.env.INDEXER_MANAGEMENT_SERVER_PORT}`,
+    graphNodeStatus: process.env.GRAPH_NODE,
+    indexerManagementServer: process.env.INDEXER_MANAGEMENT_SERVER_PORT,
     graphNetworkUrl: process.env.NETWORK_URL,
   });
 

--- a/src/examples/poi-crosschecker/poi-crosschecker.ts
+++ b/src/examples/poi-crosschecker/poi-crosschecker.ts
@@ -20,10 +20,10 @@ const RADIO_PAYLOAD_TYPES = [
 const run = async () => {
   const clientManager = new ClientManager({
     operatorPrivateKey: process.env.RADIO_OPERATOR_PRIVATE_KEY,
-    ethNodeUrl: process.env.ETH_NODE,
+    ethNodeUrl: `http://${process.env.ETH_NODE}`,
     registry: process.env.REGISTRY_SUBGRAPH,
-    graphNodeStatus: `http://${process.env.GRAPH_NODE_HOST}:8030/graphql`,
-    indexerManagementServer: `http://${process.env.INDEXER_MANAGEMENT_SERVER}`,
+    graphNodeStatus: `http://${process.env.GRAPH_NODE}/graphql`,
+    indexerManagementServer: `http://${process.env.INDEXER_MANAGEMENT_SERVER_PORT}`,
     graphNetworkUrl: process.env.NETWORK_URL,
   });
 

--- a/src/examples/poi-crosschecker/queries.ts
+++ b/src/examples/poi-crosschecker/queries.ts
@@ -133,8 +133,7 @@ export async function fetchPOI(
     return result.data.proofOfIndexing;
   } catch {
     console.warn(
-      `⚠️ No POI fetched from the local graph-node for subgraph ${subgraph}.`
-        .yellow
+      `⚠️ No POI fetched from the graph node for subgraph ${subgraph}.`.yellow
     );
   }
 }

--- a/src/examples/poi-crosschecker/utils.ts
+++ b/src/examples/poi-crosschecker/utils.ts
@@ -34,6 +34,7 @@ export function processAttestations(localnPOIs, nPOIs, targetBlock) {
       block: targetBlock,
       attestations,
       mostStaked: topAttestation.nPOI,
+      indexerAddresses: topAttestation.indexers,
       localNPOI,
     });
 
@@ -78,16 +79,28 @@ export const printNPOIs = (nPOIs: Map<string, Map<string, Attestation[]>>) => {
   });
 };
 
-export const sortAttestations = (attestations: Attestation[]) =>
-  attestations.sort((a, b) => {
-    if (a.stakeWeight < b.stakeWeight) {
-      return 1;
-    } else if (a.stakeWeight > b.stakeWeight) {
-      return -1;
-    } else {
-      return 0;
-    }
+//TODO: modify attestation types
+export const sortAttestations = (attestations: Attestation[]) => {
+  const groups = [];
+  attestations.forEach((attestation: Attestation) => {
+    groups[attestation.nPOI] = groups[attestation.nPOI]
+      ? {
+          nPOI: attestation.nPOI,
+          stakeWeight: groups[attestation.nPOI] + attestation.stakeWeight,
+          indexers: [
+            ...groups[attestation.nPOI].indexers,
+            attestation.indexerAddress,
+          ],
+        }
+      : {
+          nPOI: attestation.nPOI,
+          stakeWeight: attestation.stakeWeight,
+          indexers: [attestation.indexerAddress],
+        };
   });
+
+  return groups.sort((a, b) => Number(a.stakeWeight - b.stakeWeight));
+};
 
 export const storeAttestations = (nPOIs, attestation) => {
   const deployment = attestation.deployment;

--- a/src/examples/poi-crosschecker/utils.ts
+++ b/src/examples/poi-crosschecker/utils.ts
@@ -80,26 +80,25 @@ export const printNPOIs = (nPOIs: Map<string, Map<string, Attestation[]>>) => {
 };
 
 //TODO: modify attestation types
-export const sortAttestations = (attestations: Attestation[]) => {
+export const sortAttestations = (attestations: Attestation[])=> {
   const groups = [];
   attestations.forEach((attestation: Attestation) => {
-    groups[attestation.nPOI] = groups[attestation.nPOI]
-      ? {
-          nPOI: attestation.nPOI,
-          stakeWeight: groups[attestation.nPOI] + attestation.stakeWeight,
-          indexers: [
-            ...groups[attestation.nPOI].indexers,
-            attestation.indexerAddress,
-          ],
-        }
-      : {
-          nPOI: attestation.nPOI,
-          stakeWeight: attestation.stakeWeight,
-          indexers: [attestation.indexerAddress],
-        };
+    // if match with group's nPOI, update that group
+    const matchedGroup = groups.find(g => g.nPOI === attestation.nPOI)
+    if (matchedGroup){
+      matchedGroup.stakeWeight += attestation.stakeWeight
+      matchedGroup.indexers.push(attestation.indexerAddress)
+    }else{
+      groups.push({
+        nPOI: attestation.nPOI,
+        stakeWeight: attestation.stakeWeight,
+        indexers: [attestation.indexerAddress],
+      })
+    }
   });
 
-  return groups.sort((a, b) => Number(a.stakeWeight - b.stakeWeight));
+  const sorted = groups.sort((a, b) => Number(a.stakeWeight - b.stakeWeight))
+  return sorted;
 };
 
 export const storeAttestations = (nPOIs, attestation) => {

--- a/src/tests/integration/mappings/bad_poi.json
+++ b/src/tests/integration/mappings/bad_poi.json
@@ -1,0 +1,14 @@
+{
+  "request": {
+    "url": "/mock/graphql"
+  },
+  "response": {
+    "status": 200,
+    "jsonBody": {
+      "data": { "proofOfIndexing": "0x00000000101010101010101010101" }
+    },
+    "headers": {
+      "Content-Type": "application/json"
+    }
+  }
+}

--- a/src/tests/unit/helper.test.ts
+++ b/src/tests/unit/helper.test.ts
@@ -30,11 +30,11 @@ const setup = async () => {
   observer = new Observer();
 
   clientManager = new ClientManager({
-    ethNodeUrl: `http://${ETH_NODE}`,
+    ethNodeUrl: ETH_NODE,
     operatorPrivateKey: RADIO_OPERATOR_PRIVATE_KEY,
     registry: REGISTRY_SUBGRAPH,
-    graphNodeStatus: `http://${GRAPH_NODE_HOST}:8030/graphql`,
-    indexerManagementServer: `http://${INDEXER_MANAGEMENT_SERVER}`,
+    graphNodeStatus: GRAPH_NODE_HOST,
+    indexerManagementServer: INDEXER_MANAGEMENT_SERVER,
     graphNetworkUrl: NETWORK_URL,
   });
 


### PR DESCRIPTION
Running multiple instances in the docker compose for testing is currently limited to the number of unique operator keys one has, so currently we are still not distinguishing our own address among attestations. I think we can mock the registry subgraph endpoint but then the instances won't exactly test for registry validity.

Also while testing around, I remembered that within `sortAttestations`, before `attestations.sort`, we should group attestations together by the same POI and sum their `stakeWeight`, which I would consider the first bug our integration test has caught:) 